### PR TITLE
Fix invalid widget attachment

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -34,7 +34,6 @@ namespace Contacts {
 
         protected override void activate () {
             var window = new Gtk.ApplicationWindow (this);
-            var main = new Gtk.Grid ();
 
             var contact_list = new ContactList ();
             window.add (contact_list);
@@ -46,7 +45,6 @@ namespace Contacts {
 
             window.title = "Contacts";
             window.set_default_size (900, 640);
-            window.add (main);
             window.show_all ();
 
             contact_list.parse_local_vcard_threaded ();


### PR DESCRIPTION
Fixes the following error message is shown on app launch:

```
(Application:5290): Gtk-WARNING **: 23:53:56.795: Attempting to add a widget with type GtkGrid to a GtkApplicationWindow, but as a GtkBin subclass a GtkApplicationWindow can only contain one widget at a time; it already contains a widget of type ContactsContactList
```
